### PR TITLE
Enabled proper gpu support

### DIFF
--- a/crowd_sim/envs/utils/state.py
+++ b/crowd_sim/envs/utils/state.py
@@ -69,7 +69,10 @@ class JointState(object):
             robot_state_tensor = robot_state_tensor.unsqueeze(0)
             human_states_tensor = human_states_tensor.unsqueeze(0)
 
-        if device is not None:
+        if device == torch.device('cuda:0'):
+            robot_state_tensor = robot_state_tensor.cuda()
+            human_states_tensor = human_states_tensor.cuda()
+        elif device is not None:
             robot_state_tensor.to(device)
             human_states_tensor.to(device)
 
@@ -79,10 +82,10 @@ class JointState(object):
 def tensor_to_joint_state(state):
     robot_state, human_states = state
 
-    robot_state = robot_state.squeeze().data.numpy()
+    robot_state = robot_state.cpu().squeeze().data.numpy()
     robot_state = FullState(robot_state[0], robot_state[1], robot_state[2], robot_state[3], robot_state[4],
                             robot_state[5], robot_state[6], robot_state[7], robot_state[8])
-    human_states = human_states.squeeze(0).data.numpy()
+    human_states = human_states.cpu().squeeze(0).data.numpy()
     human_states = [ObservableState(human_state[0], human_state[1], human_state[2], human_state[3],
                                     human_state[4]) for human_state in human_states]
 


### PR DESCRIPTION
Previous to these changes the tensor device would be set as cpu even if gpu was selected previously. This results in a RuntimeError later on when e.g. running a test case:

```
Traceback (most recent call last):
  File "/home/guest/Projektarbeit-Urbant/temp/urbant_socialrl/crowdnav_gazebo_interface/crowdnav_side/crowdnav_controller.py", line 85, in find_action_for_state
    action = self.policy.predict(state)
  File "/home/guest/Projektarbeit-Urbant/RelationalGraphLearning/crowd_nav/policy/model_predictive_rl.py", line 217, in predict
    action_space_clipped = self.action_clip(state_tensor, self.action_space, self.planning_width)
  File "/home/guest/Projektarbeit-Urbant/RelationalGraphLearning/crowd_nav/policy/model_predictive_rl.py", line 245, in action_clip
    next_state_est = self.state_predictor(state, action)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/guest/Projektarbeit-Urbant/RelationalGraphLearning/crowd_nav/policy/state_predictor.py", line 29, in forward
    state_embedding = self.graph_model(state)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/guest/Projektarbeit-Urbant/RelationalGraphLearning/crowd_nav/policy/graph_model.py", line 109, in forward
    robot_state_embedings = self.w_r(robot_state)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/modules/container.py", line 100, in forward
    input = module(input)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/modules/linear.py", line 87, in forward
    return F.linear(input, self.weight, self.bias)
  File "/home/guest/Projektarbeit-Urbant/venv/lib/python3.6/site-packages/torch/nn/functional.py", line 1612, in linear
    output = input.matmul(weight.t())
RuntimeError: Expected object of device type cuda but got device type cpu for argument #1 'self' in call to _th_mm
```

These changes fix that error.